### PR TITLE
Renamed repository

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,10 +53,10 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Added
 
-- [#217](https://github.com/zendframework/ZendDeveloperTools/pull/217) adds
+- [#217](https://github.com/zendframework/zend-developer-tools/pull/217) adds
   support in the `SerializableException` for PHP 7 Throwables, including Error
   types.
-- [#220](https://github.com/zendframework/ZendDeveloperTools/pull/220) adds
+- [#220](https://github.com/zendframework/zend-developer-tools/pull/220) adds
   support for displaying matched route parameters other than just the controller
   and action.
 
@@ -70,9 +70,9 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Fixed
 
-- [#215](https://github.com/zendframework/ZendDeveloperTools/pull/215) replaces
+- [#215](https://github.com/zendframework/zend-developer-tools/pull/215) replaces
   the ZF logo to remove the "2".
-- [#218](https://github.com/zendframework/ZendDeveloperTools/pull/218) updates
+- [#218](https://github.com/zendframework/zend-developer-tools/pull/218) updates
   the logic for retrieving a zend-db `Adapter` to only do so if `db`
   configuration also exists; this ensures the toolbar does not cause a fatal
   error if zend-db is installed but no adapter configured.
@@ -81,7 +81,7 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Added
 
-- [#213](https://github.com/zendframework/ZendDeveloperTools/pull/213) adds
+- [#213](https://github.com/zendframework/zend-developer-tools/pull/213) adds
   support for zend-mvc, zend-eventmanager, and zend-servicemanager v3.
 
 ### Deprecated

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Zend Developer Tools
 
-[![Build Status](https://secure.travis-ci.org/zendframework/ZendDeveloperTools.svg?branch=master)](https://secure.travis-ci.org/zendframework/ZendDeveloperTools)
-[![Coverage Status](https://coveralls.io/repos/github/zendframework/ZendDeveloperTools/badge.svg?branch=master)](https://coveralls.io/github/zendframework/ZendDeveloperTools?branch=master)
+[![Build Status](https://secure.travis-ci.org/zendframework/zend-developer-tools.svg?branch=master)](https://secure.travis-ci.org/zendframework/zend-developer-tools)
+[![Coverage Status](https://coveralls.io/repos/github/zendframework/zend-developer-tools/badge.svg?branch=master)](https://coveralls.io/github/zendframework/zend-developer-tools?branch=master)
 
 Module providing debug tools for use with [zend-mvc](https://docs.zendframework.com/zend-mvc) applications.
 

--- a/composer.json
+++ b/composer.json
@@ -10,9 +10,9 @@
         "module"
     ],
     "support": {
-        "issues": "https://github.com/zendframework/ZendDeveloperTools/issues",
-        "source": "https://github.com/zendframework/ZendDeveloperTools",
-        "rss": "https://github.com/zendframework/ZendDeveloperTools/releases.atom",
+        "issues": "https://github.com/zendframework/zend-developer-tools/issues",
+        "source": "https://github.com/zendframework/zend-developer-tools",
+        "rss": "https://github.com/zendframework/zend-developer-tools/releases.atom",
         "chat": "https://zendframework-slack.herokuapp.com",
         "forum": "https://discourse.zendframework.com/c/questions/components"
     },

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -11,7 +11,7 @@ read/subscribe to the following resources:
  - [Code of Conduct](CODE_OF_CONDUCT.md)
 
 If you are working on new features or refactoring
-[create a proposal](https://github.com/zendframework/ZendDeveloperTools/issues/new).
+[create a proposal](https://github.com/zendframework/zend-developer-tools/issues/new).
 
 ## RUNNING TESTS
 
@@ -20,8 +20,8 @@ To run tests:
 - Clone the repository:
 
   ```console
-  $ git clone git://github.com/zendframework/ZendDeveloperTools.git
-  $ cd ZendDeveloperTools
+  $ git clone git://github.com/zendframework/zend-developer-tools.git
+  $ cd zend-developer-tools
   ```
 
 - Install dependencies via composer:
@@ -72,19 +72,19 @@ pull your work into the master repository. We recommend using
 [GitHub](https://github.com), as that is where the component is already hosted.
 
 1. Setup a [GitHub account](https://github.com/), if you haven't yet
-2. Fork the repository (https://github.com/zendframework/ZendDeveloperTools)
+2. Fork the repository (https://github.com/zendframework/zend-developer-tools)
 3. Clone the canonical repository locally and enter it.
 
    ```console
-   $ git clone git://github.com/zendframework/ZendDeveloperTools.git
-   $ cd ZendDeveloperTools
+   $ git clone git://github.com/zendframework/zend-developer-tools.git
+   $ cd zend-developer-tools
    ```
 
 4. Add a remote to your fork; substitute your GitHub username in the command
    below.
 
    ```console
-   $ git remote add {username} git@github.com:{username}/ZendDeveloperTools.git
+   $ git remote add {username} git@github.com:{username}/zend-developer-tools.git
    $ git fetch {username}
    ```
 
@@ -147,7 +147,7 @@ Delta compression using up to 2 threads.
 Compression objects: 100% (18/18), done.
 Writing objects: 100% (20/20), 8.19KiB, done.
 Total 20 (delta 12), reused 0 (delta 0)
-To ssh://git@github.com/{username}/ZendDeveloperTools.git
+To ssh://git@github.com/{username}/zend-developer-tools.git
    b5583aa..4f51698  HEAD -> master
 ```
 

--- a/docs/ISSUE_TEMPLATE.md
+++ b/docs/ISSUE_TEMPLATE.md
@@ -1,4 +1,4 @@
- - [ ] I was not able to find an [open](https://github.com/zendframework/ZendDeveloperTools/issues?q=is%3Aopen) or [closed](https://github.com/zendframework/ZendDeveloperTools/issues?q=is%3Aclosed) issue matching what I'm seeing.
+ - [ ] I was not able to find an [open](https://github.com/zendframework/zend-developer-tools/issues?q=is%3Aopen) or [closed](https://github.com/zendframework/zend-developer-tools/issues?q=is%3Aclosed) issue matching what I'm seeing.
  - [ ] This is not a question. (Questions should be asked on [chat](https://zendframework.slack.com/) ([Signup here](https://zendframework-slack.herokuapp.com/)) or our [forums](https://discourse.zendframework.com/).)
 
 Provide a narrative description of what you are trying to accomplish.

--- a/docs/SUPPORT.md
+++ b/docs/SUPPORT.md
@@ -7,7 +7,7 @@ Zend Framework offers three support channels:
 - For detailed questions (e.g., those requiring examples) use our
   [forums](https://discourse.zendframework.com/c/questions/components)
 - To report issues, use this repository's
-  [issue tracker](https://github.com/zendframework/ZendDeveloperTools/issues/new)
+  [issue tracker](https://github.com/zendframework/zend-developer-tools/issues/new)
 
 **DO NOT** use the issue tracker to ask questions; use chat or the forums for
 that. Questions posed to the issue tracker will be closed.

--- a/src/Collector/AbstractCollector.php
+++ b/src/Collector/AbstractCollector.php
@@ -1,8 +1,8 @@
 <?php
 /**
- * @see       https://github.com/zendframework/ZendDeveloperTools for the canonical source repository
+ * @see       https://github.com/zendframework/zend-developer-tools for the canonical source repository
  * @copyright Copyright (c) 2011-2018 Zend Technologies USA Inc. (https://www.zend.com)
- * @license   https://github.com/zendframework/ZendDeveloperTools/blob/master/LICENSE.md New BSD License
+ * @license   https://github.com/zendframework/zend-developer-tools/blob/master/LICENSE.md New BSD License
  */
 
 namespace ZendDeveloperTools\Collector;

--- a/src/Collector/AutoHideInterface.php
+++ b/src/Collector/AutoHideInterface.php
@@ -1,8 +1,8 @@
 <?php
 /**
- * @see       https://github.com/zendframework/ZendDeveloperTools for the canonical source repository
+ * @see       https://github.com/zendframework/zend-developer-tools for the canonical source repository
  * @copyright Copyright (c) 2011-2018 Zend Technologies USA Inc. (https://www.zend.com)
- * @license   https://github.com/zendframework/ZendDeveloperTools/blob/master/LICENSE.md New BSD License
+ * @license   https://github.com/zendframework/zend-developer-tools/blob/master/LICENSE.md New BSD License
  */
 
 namespace ZendDeveloperTools\Collector;

--- a/src/Collector/CollectorInterface.php
+++ b/src/Collector/CollectorInterface.php
@@ -1,8 +1,8 @@
 <?php
 /**
- * @see       https://github.com/zendframework/ZendDeveloperTools for the canonical source repository
+ * @see       https://github.com/zendframework/zend-developer-tools for the canonical source repository
  * @copyright Copyright (c) 2011-2018 Zend Technologies USA Inc. (https://www.zend.com)
- * @license   https://github.com/zendframework/ZendDeveloperTools/blob/master/LICENSE.md New BSD License
+ * @license   https://github.com/zendframework/zend-developer-tools/blob/master/LICENSE.md New BSD License
  */
 
 namespace ZendDeveloperTools\Collector;

--- a/src/Collector/ConfigCollector.php
+++ b/src/Collector/ConfigCollector.php
@@ -1,8 +1,8 @@
 <?php
 /**
- * @see       https://github.com/zendframework/ZendDeveloperTools for the canonical source repository
+ * @see       https://github.com/zendframework/zend-developer-tools for the canonical source repository
  * @copyright Copyright (c) 2011-2018 Zend Technologies USA Inc. (https://www.zend.com)
- * @license   https://github.com/zendframework/ZendDeveloperTools/blob/master/LICENSE.md New BSD License
+ * @license   https://github.com/zendframework/zend-developer-tools/blob/master/LICENSE.md New BSD License
  */
 
 namespace ZendDeveloperTools\Collector;

--- a/src/Collector/DbCollector.php
+++ b/src/Collector/DbCollector.php
@@ -1,8 +1,8 @@
 <?php
 /**
- * @see       https://github.com/zendframework/ZendDeveloperTools for the canonical source repository
+ * @see       https://github.com/zendframework/zend-developer-tools for the canonical source repository
  * @copyright Copyright (c) 2011-2018 Zend Technologies USA Inc. (https://www.zend.com)
- * @license   https://github.com/zendframework/ZendDeveloperTools/blob/master/LICENSE.md New BSD License
+ * @license   https://github.com/zendframework/zend-developer-tools/blob/master/LICENSE.md New BSD License
  */
 
 namespace ZendDeveloperTools\Collector;

--- a/src/Collector/EventCollectorInterface.php
+++ b/src/Collector/EventCollectorInterface.php
@@ -1,8 +1,8 @@
 <?php
 /**
- * @see       https://github.com/zendframework/ZendDeveloperTools for the canonical source repository
+ * @see       https://github.com/zendframework/zend-developer-tools for the canonical source repository
  * @copyright Copyright (c) 2011-2018 Zend Technologies USA Inc. (https://www.zend.com)
- * @license   https://github.com/zendframework/ZendDeveloperTools/blob/master/LICENSE.md New BSD License
+ * @license   https://github.com/zendframework/zend-developer-tools/blob/master/LICENSE.md New BSD License
  */
 
 namespace ZendDeveloperTools\Collector;

--- a/src/Collector/ExceptionCollector.php
+++ b/src/Collector/ExceptionCollector.php
@@ -1,8 +1,8 @@
 <?php
 /**
- * @see       https://github.com/zendframework/ZendDeveloperTools for the canonical source repository
+ * @see       https://github.com/zendframework/zend-developer-tools for the canonical source repository
  * @copyright Copyright (c) 2011-2018 Zend Technologies USA Inc. (https://www.zend.com)
- * @license   https://github.com/zendframework/ZendDeveloperTools/blob/master/LICENSE.md New BSD License
+ * @license   https://github.com/zendframework/zend-developer-tools/blob/master/LICENSE.md New BSD License
  */
 
 namespace ZendDeveloperTools\Collector;

--- a/src/Collector/MailCollector.php
+++ b/src/Collector/MailCollector.php
@@ -1,8 +1,8 @@
 <?php
 /**
- * @see       https://github.com/zendframework/ZendDeveloperTools for the canonical source repository
+ * @see       https://github.com/zendframework/zend-developer-tools for the canonical source repository
  * @copyright Copyright (c) 2011-2018 Zend Technologies USA Inc. (https://www.zend.com)
- * @license   https://github.com/zendframework/ZendDeveloperTools/blob/master/LICENSE.md New BSD License
+ * @license   https://github.com/zendframework/zend-developer-tools/blob/master/LICENSE.md New BSD License
  */
 
 namespace ZendDeveloperTools\Collector;

--- a/src/Collector/MemoryCollector.php
+++ b/src/Collector/MemoryCollector.php
@@ -1,8 +1,8 @@
 <?php
 /**
- * @see       https://github.com/zendframework/ZendDeveloperTools for the canonical source repository
+ * @see       https://github.com/zendframework/zend-developer-tools for the canonical source repository
  * @copyright Copyright (c) 2011-2018 Zend Technologies USA Inc. (https://www.zend.com)
- * @license   https://github.com/zendframework/ZendDeveloperTools/blob/master/LICENSE.md New BSD License
+ * @license   https://github.com/zendframework/zend-developer-tools/blob/master/LICENSE.md New BSD License
  */
 namespace ZendDeveloperTools\Collector;
 

--- a/src/Collector/RequestCollector.php
+++ b/src/Collector/RequestCollector.php
@@ -1,8 +1,8 @@
 <?php
 /**
- * @see       https://github.com/zendframework/ZendDeveloperTools for the canonical source repository
+ * @see       https://github.com/zendframework/zend-developer-tools for the canonical source repository
  * @copyright Copyright (c) 2011-2018 Zend Technologies USA Inc. (https://www.zend.com)
- * @license   https://github.com/zendframework/ZendDeveloperTools/blob/master/LICENSE.md New BSD License
+ * @license   https://github.com/zendframework/zend-developer-tools/blob/master/LICENSE.md New BSD License
  */
 
 namespace ZendDeveloperTools\Collector;

--- a/src/Collector/TimeCollector.php
+++ b/src/Collector/TimeCollector.php
@@ -1,8 +1,8 @@
 <?php
 /**
- * @see       https://github.com/zendframework/ZendDeveloperTools for the canonical source repository
+ * @see       https://github.com/zendframework/zend-developer-tools for the canonical source repository
  * @copyright Copyright (c) 2011-2018 Zend Technologies USA Inc. (https://www.zend.com)
- * @license   https://github.com/zendframework/ZendDeveloperTools/blob/master/LICENSE.md New BSD License
+ * @license   https://github.com/zendframework/zend-developer-tools/blob/master/LICENSE.md New BSD License
  */
 namespace ZendDeveloperTools\Collector;
 

--- a/src/Controller/DeveloperToolsController.php
+++ b/src/Controller/DeveloperToolsController.php
@@ -1,8 +1,8 @@
 <?php
 /**
- * @see       https://github.com/zendframework/ZendDeveloperTools for the canonical source repository
+ * @see       https://github.com/zendframework/zend-developer-tools for the canonical source repository
  * @copyright Copyright (c) 2011-2018 Zend Technologies USA Inc. (https://www.zend.com)
- * @license   https://github.com/zendframework/ZendDeveloperTools/blob/master/LICENSE.md New BSD License
+ * @license   https://github.com/zendframework/zend-developer-tools/blob/master/LICENSE.md New BSD License
  */
 
 namespace ZendDeveloperTools\Controller;

--- a/src/EventLogging/EventContextInterface.php
+++ b/src/EventLogging/EventContextInterface.php
@@ -1,8 +1,8 @@
 <?php
 /**
- * @see       https://github.com/zendframework/ZendDeveloperTools for the canonical source repository
+ * @see       https://github.com/zendframework/zend-developer-tools for the canonical source repository
  * @copyright Copyright (c) 2011-2018 Zend Technologies USA Inc. (https://www.zend.com)
- * @license   https://github.com/zendframework/ZendDeveloperTools/blob/master/LICENSE.md New BSD License
+ * @license   https://github.com/zendframework/zend-developer-tools/blob/master/LICENSE.md New BSD License
  */
 
 namespace ZendDeveloperTools\EventLogging;

--- a/src/EventLogging/EventContextProvider.php
+++ b/src/EventLogging/EventContextProvider.php
@@ -1,8 +1,8 @@
 <?php
 /**
- * @see       https://github.com/zendframework/ZendDeveloperTools for the canonical source repository
+ * @see       https://github.com/zendframework/zend-developer-tools for the canonical source repository
  * @copyright Copyright (c) 2011-2018 Zend Technologies USA Inc. (https://www.zend.com)
- * @license   https://github.com/zendframework/ZendDeveloperTools/blob/master/LICENSE.md New BSD License
+ * @license   https://github.com/zendframework/zend-developer-tools/blob/master/LICENSE.md New BSD License
  */
 
 namespace ZendDeveloperTools\EventLogging;

--- a/src/Exception/CollectorException.php
+++ b/src/Exception/CollectorException.php
@@ -1,8 +1,8 @@
 <?php
 /**
- * @see       https://github.com/zendframework/ZendDeveloperTools for the canonical source repository
+ * @see       https://github.com/zendframework/zend-developer-tools for the canonical source repository
  * @copyright Copyright (c) 2011-2018 Zend Technologies USA Inc. (https://www.zend.com)
- * @license   https://github.com/zendframework/ZendDeveloperTools/blob/master/LICENSE.md New BSD License
+ * @license   https://github.com/zendframework/zend-developer-tools/blob/master/LICENSE.md New BSD License
  */
 
 namespace ZendDeveloperTools\Exception;

--- a/src/Exception/ExceptionInterface.php
+++ b/src/Exception/ExceptionInterface.php
@@ -1,8 +1,8 @@
 <?php
 /**
- * @see       https://github.com/zendframework/ZendDeveloperTools for the canonical source repository
+ * @see       https://github.com/zendframework/zend-developer-tools for the canonical source repository
  * @copyright Copyright (c) 2011-2018 Zend Technologies USA Inc. (https://www.zend.com)
- * @license   https://github.com/zendframework/ZendDeveloperTools/blob/master/LICENSE.md New BSD License
+ * @license   https://github.com/zendframework/zend-developer-tools/blob/master/LICENSE.md New BSD License
  */
 
 namespace ZendDeveloperTools\Exception;

--- a/src/Exception/InvalidOptionException.php
+++ b/src/Exception/InvalidOptionException.php
@@ -1,8 +1,8 @@
 <?php
 /**
- * @see       https://github.com/zendframework/ZendDeveloperTools for the canonical source repository
+ * @see       https://github.com/zendframework/zend-developer-tools for the canonical source repository
  * @copyright Copyright (c) 2011-2018 Zend Technologies USA Inc. (https://www.zend.com)
- * @license   https://github.com/zendframework/ZendDeveloperTools/blob/master/LICENSE.md New BSD License
+ * @license   https://github.com/zendframework/zend-developer-tools/blob/master/LICENSE.md New BSD License
  */
 
 namespace ZendDeveloperTools\Exception;

--- a/src/Exception/ParameterMissingException.php
+++ b/src/Exception/ParameterMissingException.php
@@ -1,8 +1,8 @@
 <?php
 /**
- * @see       https://github.com/zendframework/ZendDeveloperTools for the canonical source repository
+ * @see       https://github.com/zendframework/zend-developer-tools for the canonical source repository
  * @copyright Copyright (c) 2011-2018 Zend Technologies USA Inc. (https://www.zend.com)
- * @license   https://github.com/zendframework/ZendDeveloperTools/blob/master/LICENSE.md New BSD License
+ * @license   https://github.com/zendframework/zend-developer-tools/blob/master/LICENSE.md New BSD License
  */
 
 namespace ZendDeveloperTools\Exception;

--- a/src/Exception/ProfilerException.php
+++ b/src/Exception/ProfilerException.php
@@ -1,8 +1,8 @@
 <?php
 /**
- * @see       https://github.com/zendframework/ZendDeveloperTools for the canonical source repository
+ * @see       https://github.com/zendframework/zend-developer-tools for the canonical source repository
  * @copyright Copyright (c) 2011-2018 Zend Technologies USA Inc. (https://www.zend.com)
- * @license   https://github.com/zendframework/ZendDeveloperTools/blob/master/LICENSE.md New BSD License
+ * @license   https://github.com/zendframework/zend-developer-tools/blob/master/LICENSE.md New BSD License
  */
 
 namespace ZendDeveloperTools\Exception;

--- a/src/Exception/SerializableException.php
+++ b/src/Exception/SerializableException.php
@@ -1,8 +1,8 @@
 <?php
 /**
- * @see       https://github.com/zendframework/ZendDeveloperTools for the canonical source repository
+ * @see       https://github.com/zendframework/zend-developer-tools for the canonical source repository
  * @copyright Copyright (c) 2011-2018 Zend Technologies USA Inc. (https://www.zend.com)
- * @license   https://github.com/zendframework/ZendDeveloperTools/blob/master/LICENSE.md New BSD License
+ * @license   https://github.com/zendframework/zend-developer-tools/blob/master/LICENSE.md New BSD License
  */
 
 namespace ZendDeveloperTools\Exception;

--- a/src/Listener/EventLoggingListenerAggregate.php
+++ b/src/Listener/EventLoggingListenerAggregate.php
@@ -1,8 +1,8 @@
 <?php
 /**
- * @see       https://github.com/zendframework/ZendDeveloperTools for the canonical source repository
+ * @see       https://github.com/zendframework/zend-developer-tools for the canonical source repository
  * @copyright Copyright (c) 2011-2018 Zend Technologies USA Inc. (https://www.zend.com)
- * @license   https://github.com/zendframework/ZendDeveloperTools/blob/master/LICENSE.md New BSD License
+ * @license   https://github.com/zendframework/zend-developer-tools/blob/master/LICENSE.md New BSD License
  */
 
 namespace ZendDeveloperTools\Listener;

--- a/src/Listener/FirePhpListener.php
+++ b/src/Listener/FirePhpListener.php
@@ -1,8 +1,8 @@
 <?php
 /**
- * @see       https://github.com/zendframework/ZendDeveloperTools for the canonical source repository
+ * @see       https://github.com/zendframework/zend-developer-tools for the canonical source repository
  * @copyright Copyright (c) 2011-2018 Zend Technologies USA Inc. (https://www.zend.com)
- * @license   https://github.com/zendframework/ZendDeveloperTools/blob/master/LICENSE.md New BSD License
+ * @license   https://github.com/zendframework/zend-developer-tools/blob/master/LICENSE.md New BSD License
  */
 
 namespace ZendDeveloperTools\Listener;

--- a/src/Listener/FlushListener.php
+++ b/src/Listener/FlushListener.php
@@ -1,8 +1,8 @@
 <?php
 /**
- * @see       https://github.com/zendframework/ZendDeveloperTools for the canonical source repository
+ * @see       https://github.com/zendframework/zend-developer-tools for the canonical source repository
  * @copyright Copyright (c) 2011-2018 Zend Technologies USA Inc. (https://www.zend.com)
- * @license   https://github.com/zendframework/ZendDeveloperTools/blob/master/LICENSE.md New BSD License
+ * @license   https://github.com/zendframework/zend-developer-tools/blob/master/LICENSE.md New BSD License
  */
 
 namespace ZendDeveloperTools\Listener;

--- a/src/Listener/ProfilerListener.php
+++ b/src/Listener/ProfilerListener.php
@@ -1,8 +1,8 @@
 <?php
 /**
- * @see       https://github.com/zendframework/ZendDeveloperTools for the canonical source repository
+ * @see       https://github.com/zendframework/zend-developer-tools for the canonical source repository
  * @copyright Copyright (c) 2011-2018 Zend Technologies USA Inc. (https://www.zend.com)
- * @license   https://github.com/zendframework/ZendDeveloperTools/blob/master/LICENSE.md New BSD License
+ * @license   https://github.com/zendframework/zend-developer-tools/blob/master/LICENSE.md New BSD License
  */
 
 namespace ZendDeveloperTools\Listener;

--- a/src/Listener/StorageListener.php
+++ b/src/Listener/StorageListener.php
@@ -1,8 +1,8 @@
 <?php
 /**
- * @see       https://github.com/zendframework/ZendDeveloperTools for the canonical source repository
+ * @see       https://github.com/zendframework/zend-developer-tools for the canonical source repository
  * @copyright Copyright (c) 2011-2018 Zend Technologies USA Inc. (https://www.zend.com)
- * @license   https://github.com/zendframework/ZendDeveloperTools/blob/master/LICENSE.md New BSD License
+ * @license   https://github.com/zendframework/zend-developer-tools/blob/master/LICENSE.md New BSD License
  */
 
 namespace ZendDeveloperTools\Listener;

--- a/src/Listener/ToolbarListener.php
+++ b/src/Listener/ToolbarListener.php
@@ -1,8 +1,8 @@
 <?php
 /**
- * @see       https://github.com/zendframework/ZendDeveloperTools for the canonical source repository
+ * @see       https://github.com/zendframework/zend-developer-tools for the canonical source repository
  * @copyright Copyright (c) 2011-2018 Zend Technologies USA Inc. (https://www.zend.com)
- * @license   https://github.com/zendframework/ZendDeveloperTools/blob/master/LICENSE.md New BSD License
+ * @license   https://github.com/zendframework/zend-developer-tools/blob/master/LICENSE.md New BSD License
  */
 
 namespace ZendDeveloperTools\Listener;

--- a/src/Match/MatchInterface.php
+++ b/src/Match/MatchInterface.php
@@ -1,8 +1,8 @@
 <?php
 /**
- * @see       https://github.com/zendframework/ZendDeveloperTools for the canonical source repository
+ * @see       https://github.com/zendframework/zend-developer-tools for the canonical source repository
  * @copyright Copyright (c) 2011-2018 Zend Technologies USA Inc. (https://www.zend.com)
- * @license   https://github.com/zendframework/ZendDeveloperTools/blob/master/LICENSE.md New BSD License
+ * @license   https://github.com/zendframework/zend-developer-tools/blob/master/LICENSE.md New BSD License
  */
 
 namespace ZendDeveloperTools;

--- a/src/Module.php
+++ b/src/Module.php
@@ -1,8 +1,8 @@
 <?php
 /**
- * @see       https://github.com/zendframework/ZendDeveloperTools for the canonical source repository
+ * @see       https://github.com/zendframework/zend-developer-tools for the canonical source repository
  * @copyright Copyright (c) 2011-2018 Zend Technologies USA Inc. (https://www.zend.com)
- * @license   https://github.com/zendframework/ZendDeveloperTools/blob/master/LICENSE.md New BSD License
+ * @license   https://github.com/zendframework/zend-developer-tools/blob/master/LICENSE.md New BSD License
  */
 
 namespace ZendDeveloperTools;

--- a/src/Options.php
+++ b/src/Options.php
@@ -1,8 +1,8 @@
 <?php
 /**
- * @see       https://github.com/zendframework/ZendDeveloperTools for the canonical source repository
+ * @see       https://github.com/zendframework/zend-developer-tools for the canonical source repository
  * @copyright Copyright (c) 2011-2018 Zend Technologies USA Inc. (https://www.zend.com)
- * @license   https://github.com/zendframework/ZendDeveloperTools/blob/master/LICENSE.md New BSD License
+ * @license   https://github.com/zendframework/zend-developer-tools/blob/master/LICENSE.md New BSD License
  */
 
 namespace ZendDeveloperTools;

--- a/src/Profiler.php
+++ b/src/Profiler.php
@@ -1,8 +1,8 @@
 <?php
 /**
- * @see       https://github.com/zendframework/ZendDeveloperTools for the canonical source repository
+ * @see       https://github.com/zendframework/zend-developer-tools for the canonical source repository
  * @copyright Copyright (c) 2011-2018 Zend Technologies USA Inc. (https://www.zend.com)
- * @license   https://github.com/zendframework/ZendDeveloperTools/blob/master/LICENSE.md New BSD License
+ * @license   https://github.com/zendframework/zend-developer-tools/blob/master/LICENSE.md New BSD License
  */
 
 namespace ZendDeveloperTools;

--- a/src/ProfilerEvent.php
+++ b/src/ProfilerEvent.php
@@ -1,8 +1,8 @@
 <?php
 /**
- * @see       https://github.com/zendframework/ZendDeveloperTools for the canonical source repository
+ * @see       https://github.com/zendframework/zend-developer-tools for the canonical source repository
  * @copyright Copyright (c) 2011-2018 Zend Technologies USA Inc. (https://www.zend.com)
- * @license   https://github.com/zendframework/ZendDeveloperTools/blob/master/LICENSE.md New BSD License
+ * @license   https://github.com/zendframework/zend-developer-tools/blob/master/LICENSE.md New BSD License
  */
 
 namespace ZendDeveloperTools;

--- a/src/Report.php
+++ b/src/Report.php
@@ -1,8 +1,8 @@
 <?php
 /**
- * @see       https://github.com/zendframework/ZendDeveloperTools for the canonical source repository
+ * @see       https://github.com/zendframework/zend-developer-tools for the canonical source repository
  * @copyright Copyright (c) 2011-2018 Zend Technologies USA Inc. (https://www.zend.com)
- * @license   https://github.com/zendframework/ZendDeveloperTools/blob/master/LICENSE.md New BSD License
+ * @license   https://github.com/zendframework/zend-developer-tools/blob/master/LICENSE.md New BSD License
  */
 
 namespace ZendDeveloperTools;

--- a/src/ReportInterface.php
+++ b/src/ReportInterface.php
@@ -1,8 +1,8 @@
 <?php
 /**
- * @see       https://github.com/zendframework/ZendDeveloperTools for the canonical source repository
+ * @see       https://github.com/zendframework/zend-developer-tools for the canonical source repository
  * @copyright Copyright (c) 2011-2018 Zend Technologies USA Inc. (https://www.zend.com)
- * @license   https://github.com/zendframework/ZendDeveloperTools/blob/master/LICENSE.md New BSD License
+ * @license   https://github.com/zendframework/zend-developer-tools/blob/master/LICENSE.md New BSD License
  */
 
 namespace ZendDeveloperTools;

--- a/src/Storage/StorageInterface.php
+++ b/src/Storage/StorageInterface.php
@@ -1,8 +1,8 @@
 <?php
 /**
- * @see       https://github.com/zendframework/ZendDeveloperTools for the canonical source repository
+ * @see       https://github.com/zendframework/zend-developer-tools for the canonical source repository
  * @copyright Copyright (c) 2011-2018 Zend Technologies USA Inc. (https://www.zend.com)
- * @license   https://github.com/zendframework/ZendDeveloperTools/blob/master/LICENSE.md New BSD License
+ * @license   https://github.com/zendframework/zend-developer-tools/blob/master/LICENSE.md New BSD License
  */
 
 namespace ZendDeveloperTools\Storage;

--- a/src/Stub/ClosureStub.php
+++ b/src/Stub/ClosureStub.php
@@ -1,8 +1,8 @@
 <?php
 /**
- * @see       https://github.com/zendframework/ZendDeveloperTools for the canonical source repository
+ * @see       https://github.com/zendframework/zend-developer-tools for the canonical source repository
  * @copyright Copyright (c) 2011-2018 Zend Technologies USA Inc. (https://www.zend.com)
- * @license   https://github.com/zendframework/ZendDeveloperTools/blob/master/LICENSE.md New BSD License
+ * @license   https://github.com/zendframework/zend-developer-tools/blob/master/LICENSE.md New BSD License
  */
 
 namespace ZendDeveloperTools\Stub;

--- a/src/View/Helper/DetailArray.php
+++ b/src/View/Helper/DetailArray.php
@@ -1,8 +1,8 @@
 <?php
 /**
- * @see       https://github.com/zendframework/ZendDeveloperTools for the canonical source repository
+ * @see       https://github.com/zendframework/zend-developer-tools for the canonical source repository
  * @copyright Copyright (c) 2011-2018 Zend Technologies USA Inc. (https://www.zend.com)
- * @license   https://github.com/zendframework/ZendDeveloperTools/blob/master/LICENSE.md New BSD License
+ * @license   https://github.com/zendframework/zend-developer-tools/blob/master/LICENSE.md New BSD License
  */
 
 namespace ZendDeveloperTools\View\Helper;

--- a/src/View/Helper/Memory.php
+++ b/src/View/Helper/Memory.php
@@ -1,8 +1,8 @@
 <?php
 /**
- * @see       https://github.com/zendframework/ZendDeveloperTools for the canonical source repository
+ * @see       https://github.com/zendframework/zend-developer-tools for the canonical source repository
  * @copyright Copyright (c) 2011-2018 Zend Technologies USA Inc. (https://www.zend.com)
- * @license   https://github.com/zendframework/ZendDeveloperTools/blob/master/LICENSE.md New BSD License
+ * @license   https://github.com/zendframework/zend-developer-tools/blob/master/LICENSE.md New BSD License
  */
 
 namespace ZendDeveloperTools\View\Helper;

--- a/src/View/Helper/Time.php
+++ b/src/View/Helper/Time.php
@@ -1,8 +1,8 @@
 <?php
 /**
- * @see       https://github.com/zendframework/ZendDeveloperTools for the canonical source repository
+ * @see       https://github.com/zendframework/zend-developer-tools for the canonical source repository
  * @copyright Copyright (c) 2011-2018 Zend Technologies USA Inc. (https://www.zend.com)
- * @license   https://github.com/zendframework/ZendDeveloperTools/blob/master/LICENSE.md New BSD License
+ * @license   https://github.com/zendframework/zend-developer-tools/blob/master/LICENSE.md New BSD License
  */
 
 namespace ZendDeveloperTools\View\Helper;

--- a/test/Collector/ConfigCollectionTest.php
+++ b/test/Collector/ConfigCollectionTest.php
@@ -1,8 +1,8 @@
 <?php
 /**
- * @see       https://github.com/zendframework/ZendDeveloperTools for the canonical source repository
+ * @see       https://github.com/zendframework/zend-developer-tools for the canonical source repository
  * @copyright Copyright (c) 2011-2018 Zend Technologies USA Inc. (https://www.zend.com)
- * @license   https://github.com/zendframework/ZendDeveloperTools/blob/master/LICENSE.md New BSD License
+ * @license   https://github.com/zendframework/zend-developer-tools/blob/master/LICENSE.md New BSD License
  */
 
 namespace ZendDeveloperToolsTest\Collector;

--- a/test/Collector/MemoryCollectorTest.php
+++ b/test/Collector/MemoryCollectorTest.php
@@ -1,8 +1,8 @@
 <?php
 /**
- * @see       https://github.com/zendframework/ZendDeveloperTools for the canonical source repository
+ * @see       https://github.com/zendframework/zend-developer-tools for the canonical source repository
  * @copyright Copyright (c) 2011-2018 Zend Technologies USA Inc. (https://www.zend.com)
- * @license   https://github.com/zendframework/ZendDeveloperTools/blob/master/LICENSE.md New BSD License
+ * @license   https://github.com/zendframework/zend-developer-tools/blob/master/LICENSE.md New BSD License
  */
 
 namespace ZendDeveloperToolsTest\Collector;

--- a/test/Exception/SerializableExceptionTest.php
+++ b/test/Exception/SerializableExceptionTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @link      http://github.com/zendframework/ZendDeveloperTools for the canonical source repository
+ * @link      http://github.com/zendframework/zend-developer-tools for the canonical source repository
  * @copyright Copyright (c) 2016 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   http://framework.zend.com/license/new-bsd New BSD License
  */

--- a/test/ModuleTest.php
+++ b/test/ModuleTest.php
@@ -1,8 +1,8 @@
 <?php
 /**
- * @see       https://github.com/zendframework/ZendDeveloperTools for the canonical source repository
+ * @see       https://github.com/zendframework/zend-developer-tools for the canonical source repository
  * @copyright Copyright (c) 2011-2018 Zend Technologies USA Inc. (https://www.zend.com)
- * @license   https://github.com/zendframework/ZendDeveloperTools/blob/master/LICENSE.md New BSD License
+ * @license   https://github.com/zendframework/zend-developer-tools/blob/master/LICENSE.md New BSD License
  */
 
 namespace ZendDeveloperToolsTest;

--- a/test/OptionsTest.php
+++ b/test/OptionsTest.php
@@ -1,8 +1,8 @@
 <?php
 /**
- * @see       https://github.com/zendframework/ZendDeveloperTools for the canonical source repository
+ * @see       https://github.com/zendframework/zend-developer-tools for the canonical source repository
  * @copyright Copyright (c) 2011-2018 Zend Technologies USA Inc. (https://www.zend.com)
- * @license   https://github.com/zendframework/ZendDeveloperTools/blob/master/LICENSE.md New BSD License
+ * @license   https://github.com/zendframework/zend-developer-tools/blob/master/LICENSE.md New BSD License
  */
 
 namespace ZendDeveloperToolsTest;


### PR DESCRIPTION
The repository has been renamed from "ZendDeveloperTools" to "zend-developer-tools", in order to make it consistent with other repository names, and to make it more consistent with tooling.